### PR TITLE
remove prettier/react extension

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["plugin:react/recommended", "prettier/react"],
+  extends: ["plugin:react/recommended"],
   settings: {
     react: {
       version: "detect",


### PR DESCRIPTION
"prettier/react" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21